### PR TITLE
document that 'clickable-headers is not needed on Windows

### DIFF
--- a/gui-doc/scribblings/gui/column-control-event-class.scrbl
+++ b/gui-doc/scribblings/gui/column-control-event-class.scrbl
@@ -4,7 +4,9 @@
 @defclass/title[column-control-event% control-event% ()]{
 
 A @racket[column-control-event%] object contains information about a
- event on an @racket[list-box%] column header.
+ event on an @racket[list-box%] column header. Except on Windows,
+ the @racket['clickable-headers] style must be specified when
+ creating a @racket[list-box%] for column events to be generated.
 
 @defconstructor[([column exact-nonnegative-integer?]
                  [event-type (or/c 'list-box-column)]

--- a/gui-doc/scribblings/gui/list-box-class.scrbl
+++ b/gui-doc/scribblings/gui/list-box-class.scrbl
@@ -81,7 +81,9 @@ The @racket[columns] list determines the number of columns in the list
  also includes @racket['clickable-headers], then a click on a header
  triggers a call to @racket[callback] with a
  @racket[column-control-event%] argument whose event type is
- @indexed-racket['list-box-column].
+ @indexed-racket['list-box-column]; for historical reasons,
+ @racket['clickable-headers] has no effect on Windows and
+ header clicks are always reported.
 
 The @racket[style] specification must include exactly one of the
  following:


### PR DESCRIPTION
While it would be nice to make things more consistent instead of
documenting the difference, it's a pretty small corner, and I worry
about breaking existing programs.

Closes racket/racket#1873