### PR TITLE
Bump gui-lib dependency to 8.2.0.1

### DIFF
--- a/gui-lib/info.rkt
+++ b/gui-lib/info.rkt
@@ -5,7 +5,7 @@
 (define deps '("srfi-lite-lib"
                "data-lib"
                ["icons" #:version "1.3"]
-               ["base" #:version "7.0.0.19"]
+               ["base" #:version "8.2.0.1"]
                "syntax-color-lib"
                ["draw-lib" #:version "1.13"]
                ["snip-lib" #:version "1.2"]


### PR DESCRIPTION
The improvement of layering support (16147c5e5a) depends
on the new API get-gui-bin-extra-search-dirs introduced
in Racket v8.2 (racket/racket@dfbb7040aa).